### PR TITLE
Allow the `color` argument to plotting SymBand to have alpha

### DIFF
--- a/src/recipes/symband.jl
+++ b/src/recipes/symband.jl
@@ -36,7 +36,9 @@ function Makie.plot!(plot::SymBand)
     linecolor = lift(plot.color, plot.linecolor) do color, linecolor
         linecolor === Makie.automatic || return linecolor
         c = to_color(color)
-        return Makie.RGB(Makie.red(c), Makie.green(c), Makie.blue(c))
+        a = Makie.alpha(c)
+        rgb = Makie.RGB(Makie.red(c), Makie.green(c), Makie.blue(c))
+        return a < 1 ? Makie.RGBA(rgb, a) : rgb
     end
 
     band!(

--- a/src/recipes/symband.jl
+++ b/src/recipes/symband.jl
@@ -36,9 +36,7 @@ function Makie.plot!(plot::SymBand)
     linecolor = lift(plot.color, plot.linecolor) do color, linecolor
         linecolor === Makie.automatic || return linecolor
         c = to_color(color)
-        a = Makie.alpha(c)
-        rgb = Makie.RGB(Makie.red(c), Makie.green(c), Makie.blue(c))
-        return a < 1 ? Makie.RGBA(rgb, a) : rgb
+        return c
     end
 
     band!(


### PR DESCRIPTION
This PR makes a minor change to how the `color` argument is treated. Currently, the recipe for SymBand throws away opacity information. But this information can be useful: I was trying to use it to plot weighted mixtures of GPs with varying opacities. This two-line fix allows for such a use. 